### PR TITLE
Recursive transformations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-requests==2.2.1
+requests>=2.2.1
+python-dateutil>=2.2
 pyasn1==0.1.6
 pyOpenSSL==0.13
 ndg-httpsclient==0.3.2

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,5 @@ setup(
     download_url='https://github.com/tictail/tictail-python/releases',
     description='Python bindings for the Tictail API',
     keywords=['tictail', 'rest', 'api'],
-    requires=requires,
-    long_description="""
-    TODO
-    """,
+    requires=requires
 )

--- a/tictail/resource/base.py
+++ b/tictail/resource/base.py
@@ -22,9 +22,9 @@ def transform_attr_value(attr, value):
     """Transforms the value of the given attribute to a different representation
     For example, `modified_at` will be transformed to a `datetime` object.
 
-    If a transformation cannot be found, then we apply the following algorithm:
-
-    (1) If `value` is a list, we apply this function on each element in the list.the original value is returned.
+    If a transformation cannot be found, and `value` is a list or a dict we
+    apply this function recursively to transform nested keys. Otherwise, the
+    original value is returned.
 
     :param attr: The attribute to transform.
     :param value: The value of the attribute to transform.


### PR DESCRIPTION
This is my proposed solution for applying transformations on values (i.e returning `datetime` objects for `created_at` and `modified_at`). It should also scale to creating actual resource objects from attributes.

An example:

``` python
[Product({
 'created_at': datetime.datetime(2014, 5, 10, 22, 43, 56),
 'currency': u'SEK',
 'description': u'This is a test product.',
 'id': u'9cVh',
 'images': [],
 'modified_at': datetime.datetime(2014, 5, 10, 23, 8, 17),
 'price': 0,
 'price_includes_tax': True,
 'quantity': 1,
 'slug': u'tictail-python-test-product',
 'status': u'published',
 'store_id': u'KGu',
 'title': u'Tictail Python Test Product',
 'unlimited': False,
 'variations': [{
  u'created_at': datetime.datetime(2014, 5, 10, 22, 43, 56),
  u'id': u'dCxc',
  u'modified_at': datetime.datetime(2014, 5, 10, 23, 8, 17),
  u'quantity': 1,
  u'title': None,
  u'unlimited': False
 }]
})]
```

@kalasjocke and @tiwilliam what do you think?
